### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,17 +9,9 @@ The MX Atrium API supports over 48,000 data connections to thousands of financia
 
 <a name="dependencies"></a>
 ## Dependencies
-- [RestSharp](https://www.nuget.org/packages/RestSharp) - 105.1.0 or later
+- [RestSharp](https://www.nuget.org/packages/RestSharp) - 105.1.0
 - [Json.NET](https://www.nuget.org/packages/Newtonsoft.Json/) - 7.0.0 or later
 - [JsonSubTypes](https://www.nuget.org/packages/JsonSubTypes/) - 1.2.0 or later
-
-The DLLs included in the package may not be the latest version. We recommend using [NuGet](https://docs.nuget.org/consume/installing-nuget) to obtain the latest version of the packages:
-```
-Install-Package RestSharp
-Install-Package Newtonsoft.Json
-Install-Package JsonSubTypes
-```
-
 
 <a name="installation"></a>
 ## Installation

--- a/atrium.sln
+++ b/atrium.sln
@@ -2,7 +2,7 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 2012
 VisualStudioVersion = 12.0.0.0
 MinimumVisualStudioVersion = 10.0.0.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Atrium", "src\Atrium\Atrium.csproj", "{C70AAAA0-4D55-4EFB-ADCD-1BE12E2923BF}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Atrium", "src\Atrium\Atrium.csproj", "{6201211B-9512-4C82-BF22-5D7150BF71E1}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Atrium.Test", "src\Atrium.Test\Atrium.Test.csproj", "{19F1DEBC-DE5E-4517-8062-F000CD499087}"
 EndProject
@@ -12,10 +12,10 @@ Global
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{C70AAAA0-4D55-4EFB-ADCD-1BE12E2923BF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{C70AAAA0-4D55-4EFB-ADCD-1BE12E2923BF}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{C70AAAA0-4D55-4EFB-ADCD-1BE12E2923BF}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{C70AAAA0-4D55-4EFB-ADCD-1BE12E2923BF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6201211B-9512-4C82-BF22-5D7150BF71E1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6201211B-9512-4C82-BF22-5D7150BF71E1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6201211B-9512-4C82-BF22-5D7150BF71E1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6201211B-9512-4C82-BF22-5D7150BF71E1}.Release|Any CPU.Build.0 = Release|Any CPU
 		{19F1DEBC-DE5E-4517-8062-F000CD499087}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{19F1DEBC-DE5E-4517-8062-F000CD499087}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{19F1DEBC-DE5E-4517-8062-F000CD499087}.Release|Any CPU.ActiveCfg = Release|Any CPU

--- a/src/atrium.Test/atrium.Test.csproj
+++ b/src/atrium.Test/atrium.Test.csproj
@@ -81,7 +81,7 @@ OpenAPI spec version: 0.1
   <Import Project="$(MsBuildToolsPath)\Microsoft.CSharp.targets" />
   <ItemGroup>
       <ProjectReference Include="..\Atrium\Atrium.csproj">
-          <Project>{C70AAAA0-4D55-4EFB-ADCD-1BE12E2923BF}</Project>
+          <Project>{6201211B-9512-4C82-BF22-5D7150BF71E1}</Project>
           <Name>Atrium</Name>
       </ProjectReference>
   </ItemGroup>

--- a/src/atrium/Client/Configuration.cs
+++ b/src/atrium/Client/Configuration.cs
@@ -28,7 +28,7 @@ namespace Atrium.Client
         /// Version of the package.
         /// </summary>
         /// <value>Version of the package.</value>
-        public const string Version = "1.10.1";
+        public const string Version = "1.10.2";
 
         /// <summary>
         /// Identifier for ISO 8601 DateTime Format
@@ -113,7 +113,7 @@ namespace Atrium.Client
         /// </summary>
         public Configuration()
         {
-            UserAgent = "MX-Codegen/1.10.1/csharp";
+            UserAgent = "MX-Codegen/1.10.2/csharp";
             BasePath = "https://vestibule.mx.com";
             DefaultHeader = new ConcurrentDictionary<string, string>();
             ApiKey = new ConcurrentDictionary<string, string>();
@@ -186,7 +186,7 @@ namespace Atrium.Client
             string tempFolderPath = null,
             string dateTimeFormat = null,
             int timeout = 100000,
-            string userAgent = "MX-Codegen/1.10.1/csharp"
+            string userAgent = "MX-Codegen/1.10.2/csharp"
             // ReSharper restore UnusedParameter.Local
             )
         {
@@ -420,7 +420,7 @@ namespace Atrium.Client
             report += "    OS: " + System.Environment.OSVersion + "\n";
             report += "    .NET Framework Version: " + System.Environment.Version  + "\n";
             report += "    Version of the API: 0.1\n";
-            report += "    SDK Package Version: 1.10.1\n";
+            report += "    SDK Package Version: 1.10.2\n";
 
             return report;
         }

--- a/src/atrium/Properties/AssemblyInfo.cs
+++ b/src/atrium/Properties/AssemblyInfo.cs
@@ -28,5 +28,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.10.1")]
-[assembly: AssemblyFileVersion("1.10.1")]
+[assembly: AssemblyVersion("1.10.2")]
+[assembly: AssemblyFileVersion("1.10.2")]

--- a/src/atrium/atrium.csproj
+++ b/src/atrium/atrium.csproj
@@ -12,7 +12,7 @@ OpenAPI spec version: 0.1
     
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{C70AAAA0-4D55-4EFB-ADCD-1BE12E2923BF}</ProjectGuid>
+    <ProjectGuid>{6201211B-9512-4C82-BF22-5D7150BF71E1}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Atrium</RootNamespace>


### PR DESCRIPTION
Recent versions of RestSharp are not compatible with our library
currently. RestSharp added an additional parameter to a method we
are using, making the method we are using "not found"
when attempting to use version 106.11.4. This updates the README to
reflect the current state.