### PR TITLE
Add optional basePath param

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ namespace Example
     {
         public void main()
         { 
-            var client = new AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID");
+            var client = new AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID", "https://vestibule.mx.com");
 
             var accountGuid = "ACT-123";  // string | The unique identifier for an `account`.
             var userGuid = "USR-123";  // string | The unique identifier for a `user`.

--- a/atrium.sln
+++ b/atrium.sln
@@ -2,7 +2,7 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 2012
 VisualStudioVersion = 12.0.0.0
 MinimumVisualStudioVersion = 10.0.0.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Atrium", "src\Atrium\Atrium.csproj", "{6201211B-9512-4C82-BF22-5D7150BF71E1}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Atrium", "src\Atrium\Atrium.csproj", "{A7E9F0F6-3C1B-4BF8-9058-455335CEF555}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Atrium.Test", "src\Atrium.Test\Atrium.Test.csproj", "{19F1DEBC-DE5E-4517-8062-F000CD499087}"
 EndProject
@@ -12,10 +12,10 @@ Global
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{6201211B-9512-4C82-BF22-5D7150BF71E1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{6201211B-9512-4C82-BF22-5D7150BF71E1}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{6201211B-9512-4C82-BF22-5D7150BF71E1}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{6201211B-9512-4C82-BF22-5D7150BF71E1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A7E9F0F6-3C1B-4BF8-9058-455335CEF555}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A7E9F0F6-3C1B-4BF8-9058-455335CEF555}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A7E9F0F6-3C1B-4BF8-9058-455335CEF555}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A7E9F0F6-3C1B-4BF8-9058-455335CEF555}.Release|Any CPU.Build.0 = Release|Any CPU
 		{19F1DEBC-DE5E-4517-8062-F000CD499087}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{19F1DEBC-DE5E-4517-8062-F000CD499087}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{19F1DEBC-DE5E-4517-8062-F000CD499087}.Release|Any CPU.ActiveCfg = Release|Any CPU

--- a/docs/AccountsApi.md
+++ b/docs/AccountsApi.md
@@ -28,7 +28,7 @@ namespace Example
     {
         public void main()
         {
-            var client = new AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID");
+            var client = new AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID", "https://vestibule.mx.com");
 
             var accountGuid = "ACT-123";  // string | The unique identifier for an `account`.
             var userGuid = "USR-123";  // string | The unique identifier for a `user`.
@@ -89,7 +89,7 @@ namespace Example
     {
         public void main()
         {
-            var client = new AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID");
+            var client = new AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID", "https://vestibule.mx.com");
 
             var userGuid = "USR-123";  // string | The unique identifier for a `user`.
             var page = 1;  // int? | Specify current page. (optional) 
@@ -144,7 +144,7 @@ namespace Example
     {
         public void main()
         {
-            var client = new AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID");
+            var client = new AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID", "https://vestibule.mx.com");
 
             var accountGuid = "ACT-123";  // string | The unique identifier for an `account`.
             var userGuid = "USR-123";  // string | The unique identifier for a `user`.
@@ -197,7 +197,7 @@ namespace Example
     {
         public void main()
         {
-            var client = new AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID");
+            var client = new AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID", "https://vestibule.mx.com");
 
             var accountGuid = "ACT-123";  // string | The unique identifier for an `account`.
             var memberGuid = "MBR-123";  // string | The unique identifier for a `member`.

--- a/docs/ConnectWidgetApi.md
+++ b/docs/ConnectWidgetApi.md
@@ -25,7 +25,7 @@ namespace Example
     {
         public void main()
         {
-            var client = new AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID");
+            var client = new AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID", "https://vestibule.mx.com");
 
             var userGuid = "USR-123";  // string | The unique identifier for a `user`.
             var body = new ConnectWidgetRequestBody(); // ConnectWidgetRequestBody | Optional config options for WebView (is_mobile_webview, current_institution_code, current_member_guid, update_credentials)

--- a/docs/HoldingsApi.md
+++ b/docs/HoldingsApi.md
@@ -28,7 +28,7 @@ namespace Example
     {
         public void main()
         {
-            var client = new AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID");
+            var client = new AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID", "https://vestibule.mx.com");
 
             var userGuid = "USR-123";  // string | The unique identifier for a `user`.
 
@@ -79,7 +79,7 @@ namespace Example
     {
         public void main()
         {
-            var client = new AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID");
+            var client = new AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID", "https://vestibule.mx.com");
 
             var accountGuid = "ACT-123";  // string | The unique identifier for an `account`.
             var userGuid = "USR-123";  // string | The unique identifier for a `user`.
@@ -132,7 +132,7 @@ namespace Example
     {
         public void main()
         {
-            var client = new AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID");
+            var client = new AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID", "https://vestibule.mx.com");
 
             var memberGuid = "MBR-123";  // string | The unique identifier for a `member`.
             var userGuid = "USR-123";  // string | The unique identifier for a `user`.
@@ -185,7 +185,7 @@ namespace Example
     {
         public void main()
         {
-            var client = new AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID");
+            var client = new AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID", "https://vestibule.mx.com");
 
             var holdingGuid = "HOL-123";  // string | The unique identifier for a `holding`.
             var userGuid = "USR-123";  // string | The unique identifier for a `user`.

--- a/docs/IdentityApi.md
+++ b/docs/IdentityApi.md
@@ -26,7 +26,7 @@ namespace Example
     {
         public void main()
         {
-            var client = new AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID");
+            var client = new AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID", "https://vestibule.mx.com");
 
             var memberGuid = "MBR-123";  // string | The unique identifier for a `member`.
             var userGuid = "USR-123";  // string | The unique identifier for a `user`.
@@ -79,7 +79,7 @@ namespace Example
     {
         public void main()
         {
-            var client = new AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID");
+            var client = new AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID", "https://vestibule.mx.com");
 
             var memberGuid = "MBR-123";  // string | The unique identifier for a `member`.
             var userGuid = "USR-123";  // string | The unique identifier for a `user`.

--- a/docs/InstitutionsApi.md
+++ b/docs/InstitutionsApi.md
@@ -27,7 +27,7 @@ namespace Example
     {
         public void main()
         {
-            var client = new AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID");
+            var client = new AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID", "https://vestibule.mx.com");
 
             var name = name_example;  // string | This will list only institutions in which the appended string appears. (optional) 
             var page = 1;  // int? | Specify current page. (optional) 
@@ -90,7 +90,7 @@ namespace Example
     {
         public void main()
         {
-            var client = new AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID");
+            var client = new AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID", "https://vestibule.mx.com");
 
             var institutionCode = "example_institution_code";  // string | The institution_code of the institution.
 
@@ -141,7 +141,7 @@ namespace Example
     {
         public void main()
         {
-            var client = new AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID");
+            var client = new AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID", "https://vestibule.mx.com");
 
             var institutionCode = "example_institution_code";  // string | The institution_code of the institution.
 

--- a/docs/MembersApi.md
+++ b/docs/MembersApi.md
@@ -39,7 +39,7 @@ namespace Example
     {
         public void main()
         {
-            var client = new AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID");
+            var client = new AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID", "https://vestibule.mx.com");
 
             var memberGuid = "MBR-123";  // string | The unique identifier for a `member`.
             var userGuid = "USR-123";  // string | The unique identifier for a `user`.
@@ -92,7 +92,7 @@ namespace Example
     {
         public void main()
         {
-            var client = new AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID");
+            var client = new AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID", "https://vestibule.mx.com");
 
             var memberGuid = "MBR-123";  // string | The unique identifier for a `member`.
             var userGuid = "USR-123";  // string | The unique identifier for a `user`.
@@ -145,7 +145,7 @@ namespace Example
     {
         public void main()
         {
-            var client = new AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID");
+            var client = new AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID", "https://vestibule.mx.com");
 
             var userGuid = "USR-123";  // string | The unique identifier for a `user`.
             var body = new MemberCreateRequestBody(); // MemberCreateRequestBody | Member object to be created with optional parameters (identifier and metadata) and required parameters (credentials and institution_code)
@@ -198,7 +198,7 @@ namespace Example
     {
         public void main()
         {
-            var client = new AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID");
+            var client = new AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID", "https://vestibule.mx.com");
 
             var memberGuid = "MBR-123";  // string | The unique identifier for a `member`.
             var userGuid = "USR-123";  // string | The unique identifier for a `user`.
@@ -250,7 +250,7 @@ namespace Example
     {
         public void main()
         {
-            var client = new AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID");
+            var client = new AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID", "https://vestibule.mx.com");
 
             var memberGuid = "MBR-123";  // string | The unique identifier for a `member`.
             var userGuid = "USR-123";  // string | The unique identifier for a `user`.
@@ -303,7 +303,7 @@ namespace Example
     {
         public void main()
         {
-            var client = new AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID");
+            var client = new AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID", "https://vestibule.mx.com");
 
             var memberGuid = "MBR-123";  // string | The unique identifier for a `member`.
             var userGuid = "USR-123";  // string | The unique identifier for a `user`.
@@ -360,7 +360,7 @@ namespace Example
     {
         public void main()
         {
-            var client = new AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID");
+            var client = new AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID", "https://vestibule.mx.com");
 
             var memberGuid = "MBR-123";  // string | The unique identifier for a `member`.
             var userGuid = "USR-123";  // string | The unique identifier for a `user`.
@@ -413,7 +413,7 @@ namespace Example
     {
         public void main()
         {
-            var client = new AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID");
+            var client = new AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID", "https://vestibule.mx.com");
 
             var memberGuid = "MBR-123";  // string | The unique identifier for a `member`.
             var userGuid = "USR-123";  // string | The unique identifier for a `user`.
@@ -466,7 +466,7 @@ namespace Example
     {
         public void main()
         {
-            var client = new AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID");
+            var client = new AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID", "https://vestibule.mx.com");
 
             var memberGuid = "MBR-123";  // string | The unique identifier for a `member`.
             var userGuid = "USR-123";  // string | The unique identifier for a `user`.
@@ -527,7 +527,7 @@ namespace Example
     {
         public void main()
         {
-            var client = new AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID");
+            var client = new AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID", "https://vestibule.mx.com");
 
             var userGuid = "USR-123";  // string | The unique identifier for a `user`.
             var page = 1;  // int? | Specify current page. (optional) 
@@ -582,7 +582,7 @@ namespace Example
     {
         public void main()
         {
-            var client = new AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID");
+            var client = new AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID", "https://vestibule.mx.com");
 
             var memberGuid = "MBR-123";  // string | The unique identifier for a `member`.
             var userGuid = "USR-123";  // string | The unique identifier for a `user`.
@@ -635,7 +635,7 @@ namespace Example
     {
         public void main()
         {
-            var client = new AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID");
+            var client = new AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID", "https://vestibule.mx.com");
 
             var memberGuid = "MBR-123";  // string | The unique identifier for a `member`.
             var userGuid = "USR-123";  // string | The unique identifier for a `user`.
@@ -688,7 +688,7 @@ namespace Example
     {
         public void main()
         {
-            var client = new AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID");
+            var client = new AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID", "https://vestibule.mx.com");
 
             var memberGuid = "MBR-123";  // string | The unique identifier for a `member`.
             var userGuid = "USR-123";  // string | The unique identifier for a `user`.
@@ -745,7 +745,7 @@ namespace Example
     {
         public void main()
         {
-            var client = new AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID");
+            var client = new AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID", "https://vestibule.mx.com");
 
             var memberGuid = "MBR-123";  // string | The unique identifier for a `member`.
             var userGuid = "USR-123";  // string | The unique identifier for a `user`.
@@ -800,7 +800,7 @@ namespace Example
     {
         public void main()
         {
-            var client = new AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID");
+            var client = new AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID", "https://vestibule.mx.com");
 
             var memberGuid = "MBR-123";  // string | The unique identifier for a `member`.
             var userGuid = "USR-123";  // string | The unique identifier for a `user`.

--- a/docs/MerchantsApi.md
+++ b/docs/MerchantsApi.md
@@ -28,7 +28,7 @@ namespace Example
     {
         public void main()
         {
-            var client = new AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID");
+            var client = new AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID", "https://vestibule.mx.com");
 
             var merchantGuid = "MCH-123";  // string | The unique identifier for a `merchant`.
 
@@ -79,7 +79,7 @@ namespace Example
     {
         public void main()
         {
-            var client = new AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID");
+            var client = new AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID", "https://vestibule.mx.com");
 
 
             try
@@ -126,7 +126,7 @@ namespace Example
     {
         public void main()
         {
-            var client = new AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID");
+            var client = new AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID", "https://vestibule.mx.com");
 
             var merchantGuid = "MCH-123";  // string | The unique identifier for a `merchant`.
 
@@ -177,7 +177,7 @@ namespace Example
     {
         public void main()
         {
-            var client = new AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID");
+            var client = new AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID", "https://vestibule.mx.com");
 
             var merchantGuid = "MCH-123";  // string | The unique identifier for a `merchant`.
             var merchantLocationGuid = "MCL-123";  // string | The unique identifier for a `merchant_location`.

--- a/docs/StatementsApi.md
+++ b/docs/StatementsApi.md
@@ -28,7 +28,7 @@ namespace Example
     {
         public void main()
         {
-            var client = new AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID");
+            var client = new AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID", "https://vestibule.mx.com");
 
             var memberGuid = "MBR-123";  // string | The unique identifier for a `member`.
             var userGuid = "USR-123";  // string | The unique identifier for a `user`.
@@ -83,7 +83,7 @@ namespace Example
     {
         public void main()
         {
-            var client = new AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID");
+            var client = new AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID", "https://vestibule.mx.com");
 
             var memberGuid = "MBR-123";  // string | The unique identifier for a `member`.
             var userGuid = "USR-123";  // string | The unique identifier for a `user`.
@@ -136,7 +136,7 @@ namespace Example
     {
         public void main()
         {
-            var client = new AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID");
+            var client = new AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID", "https://vestibule.mx.com");
 
             var memberGuid = "MBR-123";  // string | The unique identifier for a `member`.
             var userGuid = "USR-123";  // string | The unique identifier for a `user`.
@@ -193,7 +193,7 @@ namespace Example
     {
         public void main()
         {
-            var client = new AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID");
+            var client = new AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID", "https://vestibule.mx.com");
 
             var memberGuid = "MBR-123";  // string | The unique identifier for a `member`.
             var userGuid = "USR-123";  // string | The unique identifier for a `user`.

--- a/docs/TransactionsApi.md
+++ b/docs/TransactionsApi.md
@@ -27,7 +27,7 @@ namespace Example
     {
         public void main()
         {
-            var client = new AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID");
+            var client = new AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID", "https://vestibule.mx.com");
 
             var body = new TransactionsCleanseAndCategorizeRequestBody(); // TransactionsCleanseAndCategorizeRequestBody | User object to be created with optional parameters (amount, type) amd required parameters (description, identifier)
 
@@ -78,7 +78,7 @@ namespace Example
     {
         public void main()
         {
-            var client = new AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID");
+            var client = new AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID", "https://vestibule.mx.com");
 
             var userGuid = "USR-123";  // string | The unique identifier for a `user`.
             var page = 1;  // int? | Specify current page. (optional) 
@@ -137,7 +137,7 @@ namespace Example
     {
         public void main()
         {
-            var client = new AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID");
+            var client = new AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID", "https://vestibule.mx.com");
 
             var transactionGuid = "TRN-123";  // string | The unique identifier for a `transaction`.
             var userGuid = "USR-123";  // string | The unique identifier for a `user`.

--- a/docs/UsersApi.md
+++ b/docs/UsersApi.md
@@ -29,7 +29,7 @@ namespace Example
     {
         public void main()
         {
-            var client = new AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID");
+            var client = new AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID", "https://vestibule.mx.com");
 
             var body = new UserCreateRequestBody(); // UserCreateRequestBody | User object to be created with optional parameters (identifier, is_disabled, metadata)
 
@@ -80,7 +80,7 @@ namespace Example
     {
         public void main()
         {
-            var client = new AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID");
+            var client = new AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID", "https://vestibule.mx.com");
 
             var userGuid = "USR-123";  // string | The unique identifier for a `user`.
 
@@ -130,7 +130,7 @@ namespace Example
     {
         public void main()
         {
-            var client = new AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID");
+            var client = new AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID", "https://vestibule.mx.com");
 
             var page = 1;  // int? | Specify current page. (optional) 
             var recordsPerPage = 12;  // int? | Specify records per page. (optional) 
@@ -183,7 +183,7 @@ namespace Example
     {
         public void main()
         {
-            var client = new AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID");
+            var client = new AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID", "https://vestibule.mx.com");
 
             var userGuid = "USR-123";  // string | The unique identifier for a `user`.
 
@@ -234,7 +234,7 @@ namespace Example
     {
         public void main()
         {
-            var client = new AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID");
+            var client = new AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID", "https://vestibule.mx.com");
 
             var userGuid = "USR-123";  // string | The unique identifier for a `user`.
             var body = new UserUpdateRequestBody(); // UserUpdateRequestBody | User object to be updated with optional parameters (identifier, is_disabled, metadata) (optional) 

--- a/docs/VerificationApi.md
+++ b/docs/VerificationApi.md
@@ -27,7 +27,7 @@ namespace Example
     {
         public void main()
         {
-            var client = new AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID");
+            var client = new AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID", "https://vestibule.mx.com");
 
             var memberGuid = "MBR-123";  // string | The unique identifier for a `member`.
             var userGuid = "USR-123";  // string | The unique identifier for a `user`.
@@ -80,7 +80,7 @@ namespace Example
     {
         public void main()
         {
-            var client = new AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID");
+            var client = new AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID", "https://vestibule.mx.com");
 
             var accountGuid = "ACT-123";  // string | The unique identifier for an `account`.
             var userGuid = "USR-123";  // string | The unique identifier for a `user`.
@@ -133,7 +133,7 @@ namespace Example
     {
         public void main()
         {
-            var client = new AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID");
+            var client = new AtriumClient("YOUR_API_KEY", "YOUR_CLIENT_ID", "https://vestibule.mx.com");
 
             var memberGuid = "MBR-123";  // string | The unique identifier for a `member`.
             var userGuid = "USR-123";  // string | The unique identifier for a `user`.

--- a/src/Atrium/Api/AtriumClient.cs
+++ b/src/Atrium/Api/AtriumClient.cs
@@ -20,21 +20,19 @@ namespace Atrium.Api
     public UsersApi users;
     public VerificationApi verification;
 
-    public AtriumClient(string apiKey, string clientID) {
-      Configuration.Default.AddApiKey("MX-API-Key", apiKey);
-      Configuration.Default.AddApiKey("MX-Client-ID", clientID);
+    public AtriumClient(string apiKey, string clientID, string basePath = "https://vestibule.mx.com") {
       
-      this.accounts = new AccountsApi();
-      this.connectWidget = new ConnectWidgetApi();
-      this.holdings = new HoldingsApi();
-      this.identity = new IdentityApi();
-      this.institutions = new InstitutionsApi();
-      this.members = new MembersApi();
-      this.merchants = new MerchantsApi();
-      this.statements = new StatementsApi();
-      this.transactions = new TransactionsApi();
-      this.users = new UsersApi();
-      this.verification = new VerificationApi();
+      this.accounts = new AccountsApi(apiKey, clientID, basePath);
+      this.connectWidget = new ConnectWidgetApi(apiKey, clientID, basePath);
+      this.holdings = new HoldingsApi(apiKey, clientID, basePath);
+      this.identity = new IdentityApi(apiKey, clientID, basePath);
+      this.institutions = new InstitutionsApi(apiKey, clientID, basePath);
+      this.members = new MembersApi(apiKey, clientID, basePath);
+      this.merchants = new MerchantsApi(apiKey, clientID, basePath);
+      this.statements = new StatementsApi(apiKey, clientID, basePath);
+      this.transactions = new TransactionsApi(apiKey, clientID, basePath);
+      this.users = new UsersApi(apiKey, clientID, basePath);
+      this.verification = new VerificationApi(apiKey, clientID, basePath);
     }
   }
 }

--- a/src/Atrium/Api/HoldingsApi.cs
+++ b/src/Atrium/Api/HoldingsApi.cs
@@ -219,9 +219,15 @@ namespace Atrium.Api
         /// Initializes a new instance of the <see cref="HoldingsApi"/> class.
         /// </summary>
         /// <returns></returns>
-        public HoldingsApi(String basePath)
+        public HoldingsApi(String apiKey, String clientID, String basePath)
         {
-            this.Configuration = new Atrium.Client.Configuration { BasePath = basePath };
+            this.Configuration = new Atrium.Client.Configuration {
+              BasePath = basePath,
+              ApiKey = {
+                {"MX-API-Key", apiKey},
+                {"MX-Client-ID", clientID}
+              }
+            };
 
             ExceptionFactory = Atrium.Client.Configuration.DefaultExceptionFactory;
         }

--- a/src/Atrium/Api/MerchantsApi.cs
+++ b/src/Atrium/Api/MerchantsApi.cs
@@ -207,9 +207,15 @@ namespace Atrium.Api
         /// Initializes a new instance of the <see cref="MerchantsApi"/> class.
         /// </summary>
         /// <returns></returns>
-        public MerchantsApi(String basePath)
+        public MerchantsApi(String apiKey, String clientID, String basePath)
         {
-            this.Configuration = new Atrium.Client.Configuration { BasePath = basePath };
+            this.Configuration = new Atrium.Client.Configuration {
+              BasePath = basePath,
+              ApiKey = {
+                {"MX-API-Key", apiKey},
+                {"MX-Client-ID", clientID}
+              }
+            };
 
             ExceptionFactory = Atrium.Client.Configuration.DefaultExceptionFactory;
         }

--- a/src/Atrium/Api/StatementsApi.cs
+++ b/src/Atrium/Api/StatementsApi.cs
@@ -239,9 +239,15 @@ namespace Atrium.Api
         /// Initializes a new instance of the <see cref="StatementsApi"/> class.
         /// </summary>
         /// <returns></returns>
-        public StatementsApi(String basePath)
+        public StatementsApi(String apiKey, String clientID, String basePath)
         {
-            this.Configuration = new Atrium.Client.Configuration { BasePath = basePath };
+            this.Configuration = new Atrium.Client.Configuration {
+              BasePath = basePath,
+              ApiKey = {
+                {"MX-API-Key", apiKey},
+                {"MX-Client-ID", clientID}
+              }
+            };
 
             ExceptionFactory = Atrium.Client.Configuration.DefaultExceptionFactory;
         }

--- a/src/atrium.Test/atrium.Test.csproj
+++ b/src/atrium.Test/atrium.Test.csproj
@@ -81,7 +81,7 @@ OpenAPI spec version: 0.1
   <Import Project="$(MsBuildToolsPath)\Microsoft.CSharp.targets" />
   <ItemGroup>
       <ProjectReference Include="..\Atrium\Atrium.csproj">
-          <Project>{6201211B-9512-4C82-BF22-5D7150BF71E1}</Project>
+          <Project>{A7E9F0F6-3C1B-4BF8-9058-455335CEF555}</Project>
           <Name>Atrium</Name>
       </ProjectReference>
   </ItemGroup>

--- a/src/atrium/Api/AccountsApi.cs
+++ b/src/atrium/Api/AccountsApi.cs
@@ -247,9 +247,15 @@ namespace Atrium.Api
         /// Initializes a new instance of the <see cref="AccountsApi"/> class.
         /// </summary>
         /// <returns></returns>
-        public AccountsApi(String basePath)
+        public AccountsApi(String apiKey, String clientID, String basePath)
         {
-            this.Configuration = new Atrium.Client.Configuration { BasePath = basePath };
+            this.Configuration = new Atrium.Client.Configuration {
+              BasePath = basePath,
+              ApiKey = {
+                {"MX-API-Key", apiKey},
+                {"MX-Client-ID", clientID}
+              }
+            };
 
             ExceptionFactory = Atrium.Client.Configuration.DefaultExceptionFactory;
         }

--- a/src/atrium/Api/ConnectWidgetApi.cs
+++ b/src/atrium/Api/ConnectWidgetApi.cs
@@ -85,9 +85,15 @@ namespace Atrium.Api
         /// Initializes a new instance of the <see cref="ConnectWidgetApi"/> class.
         /// </summary>
         /// <returns></returns>
-        public ConnectWidgetApi(String basePath)
+        public ConnectWidgetApi(String apiKey, String clientID, String basePath)
         {
-            this.Configuration = new Atrium.Client.Configuration { BasePath = basePath };
+            this.Configuration = new Atrium.Client.Configuration {
+              BasePath = basePath,
+              ApiKey = {
+                {"MX-API-Key", apiKey},
+                {"MX-Client-ID", clientID}
+              }
+            };
 
             ExceptionFactory = Atrium.Client.Configuration.DefaultExceptionFactory;
         }

--- a/src/atrium/Api/IdentityApi.cs
+++ b/src/atrium/Api/IdentityApi.cs
@@ -131,9 +131,15 @@ namespace Atrium.Api
         /// Initializes a new instance of the <see cref="IdentityApi"/> class.
         /// </summary>
         /// <returns></returns>
-        public IdentityApi(String basePath)
+        public IdentityApi(String apiKey, String clientID, String basePath)
         {
-            this.Configuration = new Atrium.Client.Configuration { BasePath = basePath };
+            this.Configuration = new Atrium.Client.Configuration {
+              BasePath = basePath,
+              ApiKey = {
+                {"MX-API-Key", apiKey},
+                {"MX-Client-ID", clientID}
+              }
+            };
 
             ExceptionFactory = Atrium.Client.Configuration.DefaultExceptionFactory;
         }

--- a/src/atrium/Api/InstitutionsApi.cs
+++ b/src/atrium/Api/InstitutionsApi.cs
@@ -189,9 +189,15 @@ namespace Atrium.Api
         /// Initializes a new instance of the <see cref="InstitutionsApi"/> class.
         /// </summary>
         /// <returns></returns>
-        public InstitutionsApi(String basePath)
+        public InstitutionsApi(String apiKey, String clientID, String basePath)
         {
-            this.Configuration = new Atrium.Client.Configuration { BasePath = basePath };
+            this.Configuration = new Atrium.Client.Configuration {
+              BasePath = basePath,
+              ApiKey = {
+                {"MX-API-Key", apiKey},
+                {"MX-Client-ID", clientID}
+              }
+            };
 
             ExceptionFactory = Atrium.Client.Configuration.DefaultExceptionFactory;
         }

--- a/src/atrium/Api/MembersApi.cs
+++ b/src/atrium/Api/MembersApi.cs
@@ -773,9 +773,15 @@ namespace Atrium.Api
         /// Initializes a new instance of the <see cref="MembersApi"/> class.
         /// </summary>
         /// <returns></returns>
-        public MembersApi(String basePath)
+        public MembersApi(String apiKey, String clientID, String basePath)
         {
-            this.Configuration = new Atrium.Client.Configuration { BasePath = basePath };
+            this.Configuration = new Atrium.Client.Configuration {
+              BasePath = basePath,
+              ApiKey = {
+                {"MX-API-Key", apiKey},
+                {"MX-Client-ID", clientID}
+              }
+            };
 
             ExceptionFactory = Atrium.Client.Configuration.DefaultExceptionFactory;
         }

--- a/src/atrium/Api/TransactionsApi.cs
+++ b/src/atrium/Api/TransactionsApi.cs
@@ -185,9 +185,15 @@ namespace Atrium.Api
         /// Initializes a new instance of the <see cref="TransactionsApi"/> class.
         /// </summary>
         /// <returns></returns>
-        public TransactionsApi(String basePath)
+        public TransactionsApi(String apiKey, String clientID, String basePath)
         {
-            this.Configuration = new Atrium.Client.Configuration { BasePath = basePath };
+            this.Configuration = new Atrium.Client.Configuration {
+              BasePath = basePath,
+              ApiKey = {
+                {"MX-API-Key", apiKey},
+                {"MX-Client-ID", clientID}
+              }
+            };
 
             ExceptionFactory = Atrium.Client.Configuration.DefaultExceptionFactory;
         }

--- a/src/atrium/Api/UsersApi.cs
+++ b/src/atrium/Api/UsersApi.cs
@@ -257,9 +257,15 @@ namespace Atrium.Api
         /// Initializes a new instance of the <see cref="UsersApi"/> class.
         /// </summary>
         /// <returns></returns>
-        public UsersApi(String basePath)
+        public UsersApi(String apiKey, String clientID, String basePath)
         {
-            this.Configuration = new Atrium.Client.Configuration { BasePath = basePath };
+            this.Configuration = new Atrium.Client.Configuration {
+              BasePath = basePath,
+              ApiKey = {
+                {"MX-API-Key", apiKey},
+                {"MX-Client-ID", clientID}
+              }
+            };
 
             ExceptionFactory = Atrium.Client.Configuration.DefaultExceptionFactory;
         }

--- a/src/atrium/Api/VerificationApi.cs
+++ b/src/atrium/Api/VerificationApi.cs
@@ -177,9 +177,15 @@ namespace Atrium.Api
         /// Initializes a new instance of the <see cref="VerificationApi"/> class.
         /// </summary>
         /// <returns></returns>
-        public VerificationApi(String basePath)
+        public VerificationApi(String apiKey, String clientID, String basePath)
         {
-            this.Configuration = new Atrium.Client.Configuration { BasePath = basePath };
+            this.Configuration = new Atrium.Client.Configuration {
+              BasePath = basePath,
+              ApiKey = {
+                {"MX-API-Key", apiKey},
+                {"MX-Client-ID", clientID}
+              }
+            };
 
             ExceptionFactory = Atrium.Client.Configuration.DefaultExceptionFactory;
         }

--- a/src/atrium/Client/Configuration.cs
+++ b/src/atrium/Client/Configuration.cs
@@ -28,7 +28,7 @@ namespace Atrium.Client
         /// Version of the package.
         /// </summary>
         /// <value>Version of the package.</value>
-        public const string Version = "1.10.2";
+        public const string Version = "1.10.3";
 
         /// <summary>
         /// Identifier for ISO 8601 DateTime Format
@@ -113,7 +113,7 @@ namespace Atrium.Client
         /// </summary>
         public Configuration()
         {
-            UserAgent = "MX-Codegen/1.10.2/csharp";
+            UserAgent = "MX-Codegen/1.10.3/csharp";
             BasePath = "https://vestibule.mx.com";
             DefaultHeader = new ConcurrentDictionary<string, string>();
             ApiKey = new ConcurrentDictionary<string, string>();
@@ -186,7 +186,7 @@ namespace Atrium.Client
             string tempFolderPath = null,
             string dateTimeFormat = null,
             int timeout = 100000,
-            string userAgent = "MX-Codegen/1.10.2/csharp"
+            string userAgent = "MX-Codegen/1.10.3/csharp"
             // ReSharper restore UnusedParameter.Local
             )
         {
@@ -420,7 +420,7 @@ namespace Atrium.Client
             report += "    OS: " + System.Environment.OSVersion + "\n";
             report += "    .NET Framework Version: " + System.Environment.Version  + "\n";
             report += "    Version of the API: 0.1\n";
-            report += "    SDK Package Version: 1.10.2\n";
+            report += "    SDK Package Version: 1.10.3\n";
 
             return report;
         }

--- a/src/atrium/Properties/AssemblyInfo.cs
+++ b/src/atrium/Properties/AssemblyInfo.cs
@@ -28,5 +28,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.10.2")]
-[assembly: AssemblyFileVersion("1.10.2")]
+[assembly: AssemblyVersion("1.10.3")]
+[assembly: AssemblyFileVersion("1.10.3")]

--- a/src/atrium/atrium.csproj
+++ b/src/atrium/atrium.csproj
@@ -12,7 +12,7 @@ OpenAPI spec version: 0.1
     
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{6201211B-9512-4C82-BF22-5D7150BF71E1}</ProjectGuid>
+    <ProjectGuid>{A7E9F0F6-3C1B-4BF8-9058-455335CEF555}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Atrium</RootNamespace>


### PR DESCRIPTION
Adds optional basePath param as an optional third parameter when
creating an AtriumClient. This is necessary to switch between
development and production environments. If optional basePath param is
missing, the client will default to the development environment
(vestibule).